### PR TITLE
replaced re.test with str.search

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ export default function inject ( options ) {
 	return {
 		transform ( code, id ) {
 			if ( !filter( id ) ) return null;
-			if ( !firstpass.test( code ) ) return null;
+			if ( code.search( firstpass ) == -1 ) return null;
 			if ( extname( id ) !== '.js' ) return null;
 
 			let ast;


### PR DESCRIPTION
I think this fixes #4. re.test maintains state from previous searches, so it starts reporting false negatives if the injection appears in multiple files.