### PR TITLE
transform all files, not just those with names ending .js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { attachScopes, createFilter } from 'rollup-pluginutils';
-import { extname, sep } from 'path';
+import { sep } from 'path';
 import { walk } from 'estree-walker';
 import { parse } from 'acorn';
 import makeLegalIdentifier from './makeLegalIdentifier';
@@ -90,7 +90,7 @@ export default function inject ( options ) {
 		transform ( code, id ) {
 			if ( !filter( id ) ) return null;
 			if ( code.search( firstpass ) == -1 ) return null;
-			
+
 			let ast;
 
 			try {

--- a/src/index.js
+++ b/src/index.js
@@ -90,8 +90,7 @@ export default function inject ( options ) {
 		transform ( code, id ) {
 			if ( !filter( id ) ) return null;
 			if ( code.search( firstpass ) == -1 ) return null;
-			if ( extname( id ) !== '.js' ) return null;
-
+			
 			let ast;
 
 			try {


### PR DESCRIPTION
Hello.

I am currently working on a compile-to-JS language and I have decided to use rollup internally to handle the merging of the resulting JS sources. I use this plugin to inject some shared variables and it is almost perfect, except the original filenames do not end in `.js`.

So, would it be possible to remove the `extname()` line? Obviously this is a breaking change, however I figure that users who require the current set up could just add `include: ["*.js"]` to their options.

Thoughts?