### PR TITLE
Accepts wildcard import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,11 @@ export default function inject ( options ) {
 					const importLocalName = name === keypath ? name : makeLegalIdentifier( `$inject_${keypath}` );
 
 					if ( !newImports[ hash ] ) {
-						newImports[ hash ] = `import { ${module[1]} as ${importLocalName} } from '${module[0]}';`;
+						if ( modules[1] === '*' ) {
+							newImports[ hash ] = `import * as ${importLocalName} from '${module[0]}';`;
+						} else {
+							newImports[ hash ] = `import { ${module[1]} as ${importLocalName} } from '${module[0]}';`;
+						}
 					}
 
 					if ( name !== keypath ) {


### PR DESCRIPTION
This pull requests allow users to inject a module with a wildcard character. It comes in handy when you need to manually inject `regeneratorRuntime` or a custom `babelHelpers`.