### PR TITLE
alternative approach to redundant keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,8 @@ export default function inject ( options ) {
 					if ( name !== keypath ) {
 						magicString.overwrite( node.start, node.end, importLocalName, true );
 					}
+
+					return true;
 				}
 			}
 
@@ -163,7 +165,8 @@ export default function inject ( options ) {
 
 					if ( isReference( node, parent ) ) {
 						const { name, keypath } = flatten( node );
-						handleReference( node, name, keypath );
+						const handled = handleReference( node, name, keypath );
+						if ( handled ) return this.skip();
 					}
 				},
 				leave ( node ) {

--- a/test/samples/redundant-keys/main.js
+++ b/test/samples/redundant-keys/main.js
@@ -1,0 +1,1 @@
+Buffer.isBuffer('foo');

--- a/test/test.js
+++ b/test/test.js
@@ -114,4 +114,19 @@ describe( 'rollup-plugin-inject', function () {
 			assert.ok( code.indexOf( "import { Promise } from 'es6-promise'" ) !== -1, generated.code );
 		});
 	});
+
+	it( 'handles redundant keys', function () {
+		return rollup.rollup({
+			entry: 'samples/redundant-keys/main.js',
+			plugins: [
+				inject({
+					Buffer: 'Buffer',
+					'Buffer.isBuffer': 'is-buffer'
+				})
+			],
+			external: [ 'Buffer', 'is-buffer' ]
+		}).then( function ( bundle ) {
+			assert.deepEqual( bundle.imports, [ 'is-buffer' ]);
+		});
+	});
 });


### PR DESCRIPTION
See #10. This approach is simpler in that it just stops descending into member expressions that match a pattern – no book-keeping required