### PR TITLE
Windows paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,9 +139,9 @@ export default function inject ( options ) {
 
 					if ( !newImports[ hash ] ) {
 						if ( module[1] === '*' ) {
-							newImports[ hash ] = `import * as ${importLocalName} from '${module[0]}';`;
+							newImports[ hash ] = `import * as ${importLocalName} from ${JSON.stringify(module[0])};`;
 						} else {
-							newImports[ hash ] = `import { ${module[1]} as ${importLocalName} } from '${module[0]}';`;
+							newImports[ hash ] = `import { ${module[1]} as ${importLocalName} } from ${JSON.stringify(module[0])};`;
 						}
 					}
 

--- a/test/samples/windows/main.js
+++ b/test/samples/windows/main.js
@@ -1,0 +1,1 @@
+Buffer.isBuffer('foo');

--- a/test/test.js
+++ b/test/test.js
@@ -167,4 +167,18 @@ describe( 'rollup-plugin-inject', function () {
 			fn( require, assert );
 		});
 	});
+	it( 'works with windows paths', function () {
+		var external = [ 'C:\\Users\\IEUser\\projects\\node_modules\\process-es6\\browser.js' ];
+		return rollup.rollup({
+			entry: 'samples/redundant-keys/main.js',
+			plugins: [
+				inject({
+					Buffer: 'C:\\Users\\IEUser\\projects\\node_modules\\process-es6\\browser.js'
+				})
+			],
+			external: external
+		}).then( function ( bundle ) {
+			assert.deepEqual(bundle.imports, external);
+		});
+	});
 });


### PR DESCRIPTION
so windows paths are usually done with a '\\' but in certain circumstances they turn into a '\' randomly which just sort of breaks things 