### PR TITLE
perf(): return ast to amortize plugin cost

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "eslint": "^5.16.0",
     "mocha": "^6.0.0",
     "prettier": "^1.17.1",
-    "rollup": "^1.0.0",
+    "rollup": "^1.15.1",
     "rollup-plugin-buble": "^0.19.6",
     "shx": "^0.3.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export default function inject(options) {
   }
 
   const firstpass = new RegExp(
-    `(?:${Object.keys(modules)
+    `(?:${Array.from(modulesMap.keys())
       .map(escape)
       .join("|")})`,
     "g"
@@ -81,7 +81,7 @@ export default function inject(options) {
 
     transform(code, id) {
       if (!filter(id)) return null;
-      if (!firstpass.test(code)) return null;
+      if (code.search(firstpass) === -1) return null;
 
       if (sep !== "/") id = id.split(sep).join("/");
 

--- a/test/samples/non-js/main.js
+++ b/test/samples/non-js/main.js
@@ -1,4 +1,4 @@
 import './styles.css';
 import foo from './foo.es6';
 
-assert.equal( foo, '../baz' );
+assert.equal( foo, path.join('..','baz') );

--- a/test/test.js
+++ b/test/test.js
@@ -157,7 +157,7 @@ describe("rollup-plugin-inject", () => {
 
     const { code } = output[0];
 
-    const fn = new Function("require", "assert", code);
-    fn(require, assert);
+    const fn = new Function("require", "path", "assert", code);
+    fn(require, path, assert);
   });
 });


### PR DESCRIPTION
- Port objects to Maps and Sets
- Port functions to const arrow functions (https://benediktmeurer.de/2017/06/29/javascript-optimization-patterns-part2/)
- Return ast when no transform was performed 
- Skip regex presearch since the parse cost will be amortized  
- Renamed module to mod to prevent variable shadowing the global module (IDE highlighting gets confused)