### PR TITLE
fix: fix sourcemaps warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ export default function inject(options) {
       .join("|")})`,
     "g"
   );
-  const sourceMap = options.sourceMap !== false;
+  const sourceMap = options.sourceMap !== false && options.sourcemap !== false;
 
   return {
     name: "inject",
@@ -178,7 +178,8 @@ export default function inject(options) {
       if (newImports.size === 0) {
         return {
           code,
-          ast
+          ast,
+          map: sourceMap ? magicString.generateMap() : null
         };
       }
       const importBlock = Array.from(newImports.values())


### PR DESCRIPTION
I'm getting this warning when using this plugin:

```
Sourcemap is likely to be incorrect: a plugin ('inject') was used
to transform files, but didn't generate a sourcemap for the
transformation. Consult the plugin documentation for help
```

By borrowing [some code from rollup-plugin-replace](https://github.com/rollup/rollup-plugin-replace/blob/3f01b488cc68e6be1b1171446362db0a90dbdcb9/src/index.js#L770) to handle both the `sourceMap` and `sourcemap` options, and by returning the `map` key consistently, I made the warning go away.

(Apologies for not having a reduced repro; I couldn't manage to find one. :disappointed:)