### PR TITLE
Fixes usage of sourcemap option on Windows.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,8 @@ export default function inject(options) {
     modules = Object.assign({}, options);
     delete modules.include;
     delete modules.exclude;
+    delete modules.sourceMap;
+    delete modules.sourcemap;
   }
 
   const modulesMap = new Map(Object.entries(modules));


### PR DESCRIPTION
This error occurs on Windows when using the sourcemap option:

```
[!] TypeError: mod.split is not a function
TypeError: mod.split is not a function
    at modulesMap.forEach (C:\Users\mmanders\WebstormProjects\device\node_modules\rollup-plugin-inject\dist\rollup-plugin-inject.cjs.js:70:79)
    at Map.forEach (<anonymous>)
    at inject (C:\Users\mmanders\WebstormProjects\device\node_modules\rollup-plugin-inject\dist\rollup-plugin-inject.cjs.js:67:16)
    at Object.<anonymous> (C:\Users\mmanders\WebstormProjects\device\rollup.config.js:31:5)
    at Module._compile (module.js:653:30)
    at Object.require.extensions..js (C:\Users\mmanders\WebstormProjects\device\node_modules\rollup\bin\rollup:1035:24)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
```

It tries to use `split` on the sourcemap boolean.